### PR TITLE
Upgrades gdal dependency to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "duplexify": "^3.2.0",
     "findit": "0.1.x",
     "from2": "^1.2.0",
-    "gdal": "^0.4.1",
+    "gdal": "^0.8.0",
     "morestreams": "0.1.x",
     "seq": "0.3.x",
     "through2": "^0.6.2"


### PR DESCRIPTION
Mapbox does no longer provide precompiled binaries for version ^0.4.x. I upgraded the dependency to ^0.8.0 and it's now installing fine.