### PR TITLE
handles null geometry

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,8 +106,11 @@ function fromShpFile (file, outStream) {
               return writeNextFeature();
           }
 
-          geom.transform(currentTransformation);
-          var geojson = geom.toJSON();
+          var geojson=null;
+          if (geom && geom.transform) {
+            geom.transform(currentTransformation);
+            geojson = geom.toJSON();
+          }
           var fields = feature.fields.toJSON();
           var featStr = '{"type": "Feature", "properties": ' + fields + ',"geometry": ' + geojson + '}';
 


### PR DESCRIPTION
When you try to reproject the Feature's geometry:

https://github.com/substack/shp2json/blob/master/index.js#L103-L110

A feature will `null` geometry will yield `geom = null`. Therefore, said variable won't be an object nor have a `.transform` property, causing the script to crash.

In this PR I'm handling said case setting the value of `geojson` to null by default, then ovewriting it if and only `geom` is truthy and has a `transform` property.