### PR TITLE
Updated gdal version to 0.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "duplexify": "^3.2.0",
     "findit": "0.1.x",
     "from2": "^1.2.0",
-    "gdal": "^0.9.1",
+    "gdal": "^0.10.1",
     "morestreams": "0.1.x",
     "seq": "0.3.x",
     "through2": "^0.6.2"


### PR DESCRIPTION
There's [an issue](https://github.com/OSGeo/gdal/issues/2859) with a current release of GDAL because it removes linking paths like `/usr/bin` and `/usr/lib`. Symlinking GDAL bin/libs to `/usr/local/bin` and `/usr/local/lib` seems to resolve the issue, but so does just changing node-gdal version to 0.10.1.